### PR TITLE
Create `Affinity` namedtuple and return that instead of a normal tuple

### DIFF
--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -79,9 +79,9 @@ Calculate affinity with a user
 .. code-block:: python
 
     print(ma.calculate_affinity("Luna"))
-    # (37.06659111674594, 171)
+    # Affinity(affinity=37.06659111674594, shared=171)
 
-Note that what is being returned is a tuple, containing the affinity and shared
+Note that what is being returned is a namedtuple, containing the affinity and shared
 rated anime. This can be separated into different variables as follows:
 
 .. code-block:: python
@@ -91,6 +91,17 @@ rated anime. This can be separated into different variables as follows:
     print(affinity)
     # 37.06659111674594
     print(shared)
+    # 171
+
+Alternatively, the following also works (as this is a namedtuple):
+
+.. code-block:: python
+
+    affinity = ma.calculate_affinity("Luna")
+
+    print(affinity.affinity)
+    # 37.06659111674594
+    print(affinity.shared)
     # 171
 
 Comparing scores with a user
@@ -138,6 +149,15 @@ and you're only interested in the affinity with one person.
     print(affinity)
     # 37.06659111674594
     print(shared)
+    # 171
+
+
+    # Alternatively...
+    affinity = calculate_affinity("Xinil", "Luna")
+
+    print(affinity.affinity)
+    # 37.06659111674594
+    print(affinity.shared)
     # 171
 
 .. note:: Don't use this if you're planning on calculating affinity again with one of

--- a/malaffinity/malaffinity.py
+++ b/malaffinity/malaffinity.py
@@ -5,6 +5,7 @@ import copy
 
 from . import calcs
 from . import endpoints
+from . import models
 
 from .exceptions import (
     NoAffinityError,
@@ -151,13 +152,22 @@ class MALAffinity:
         """
         Get the affinity between the "base user" and ``username``.
 
-        .. note:: The data returned will be a tuple, with the affinity
+        .. note:: The data returned will be a namedtuple, with the affinity
                   and shared rated anime. This can easily be separated
                   as follows (using the user ``Luna`` as ``username``):
 
                   .. code-block:: python
 
                       affinity, shared = ma.calculate_affinity("Luna")
+
+                  Alternatively, the following also works:
+
+                  .. code-block:: python
+
+                      affinity = ma.calculate_affinity("Luna")
+
+                  with the affinity and shared available as
+                  ``affinity.affinity`` and ``affinity.shared`` respectively.
 
         .. note:: The final affinity value may or may not be rounded,
                   depending on the value of :attr:`._round`, set at
@@ -187,4 +197,4 @@ class MALAffinity:
         if self._round is not False:
             pearson = round(pearson, self._round)
 
-        return pearson, len(scores)
+        return models.Affinity(pearson, len(scores))

--- a/malaffinity/models.py
+++ b/malaffinity/models.py
@@ -1,0 +1,7 @@
+"""malaffinity models."""
+
+
+from collections import namedtuple
+
+
+Affinity = namedtuple("Affinity", ["affinity", "shared"])


### PR DESCRIPTION
(Very late) Edit: Closes #9 

Not sure if I want to do this, will need to run tests.

Naming is a bit weird, currently repr-s as `Affinity(affinity=71.81631840166366, shared=94)`, which is repeating "affinity" a bit too much for my liking (especially when saving to var `affinity`).